### PR TITLE
Add AsyncAcmeClientSpi class which can be used to communicate with ACME server and whose methods return the Mutiny's Uni values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <version.org.glassfish.jakarta.json>2.0.1</version.org.glassfish.jakarta.json>
         <version.org.mock-server.mockserver-netty>5.4.1</version.org.mock-server.mockserver-netty>
         <version.org.wildfly.checkstyle-config>1.0.8.Final</version.org.wildfly.checkstyle-config>
+        <version.io.smallrye.reactive.mutiny>2.5.1</version.io.smallrye.reactive.mutiny>
         <version.jakarta.json.jakarta-json-api>2.0.0</version.jakarta.json.jakarta-json-api>
         <version.jmockit>1.39</version.jmockit>
         <version.junit.junit>4.13.1</version.junit.junit>

--- a/x500/cert/acme/pom.xml
+++ b/x500/cert/acme/pom.xml
@@ -77,6 +77,13 @@
             <version>${version.jakarta.json.jakarta-json-api}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/io.smallrye.reactive/mutiny -->
+        <dependency>
+            <groupId>io.smallrye.reactive</groupId>
+            <artifactId>mutiny</artifactId>
+            <version>${version.io.smallrye.reactive.mutiny}</version>
+        </dependency>
+
 
         <!-- Mock Web Server -->
         <dependency>

--- a/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/AsyncAcmeClientSpi.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/AsyncAcmeClientSpi.java
@@ -1,0 +1,253 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.security.certificate.management.x500.cert.acme;
+
+import io.smallrye.mutiny.Uni;
+import org.wildfly.security.certificate.management.x500.cert.X509CertificateChainAndSigningKey;
+
+import java.net.URL;
+import java.security.PrivateKey;
+import java.security.cert.CRLReason;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AsyncAcmeClientSpi {
+
+    private final AcmeClientSpi delegate;
+
+    public AsyncAcmeClientSpi() {
+        AsyncAcmeClientSpi impl = this;
+
+        this.delegate = new AcmeClientSpi() {
+            @Override
+            public AcmeChallenge proveIdentifierControl(AcmeAccount account, List<AcmeChallenge> challenges) throws AcmeException {
+                return impl.proveIdentifierControl(account, challenges);
+            }
+
+            @Override
+            public void cleanupAfterChallenge(AcmeAccount account, AcmeChallenge challenge) throws AcmeException {
+                impl.cleanupAfterChallenge(account, challenge);
+            }
+        };
+    }
+
+    protected abstract AcmeChallenge proveIdentifierControl(AcmeAccount account, List<AcmeChallenge> challenges) throws AcmeException;
+    protected abstract void cleanupAfterChallenge(AcmeAccount account, AcmeChallenge challenge) throws AcmeException;
+
+    public Uni<Map<AcmeResource, URL>> getResourceUrls(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.getResourceUrls(account, staging);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<AcmeMetadata> getMetadata(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.getMetadata(account, staging);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Boolean> createAccount(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.createAccount(account, staging);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Boolean> createAccount(ElytronRequestContext context, AcmeAccount account, boolean staging, boolean onlyReturnExisting) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.createAccount(account, staging, onlyReturnExisting);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> updateAccount(ElytronRequestContext context, AcmeAccount account, boolean staging, boolean termsOfServiceAgreed) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.updateAccount(account, staging, termsOfServiceAgreed);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> updateAccount(ElytronRequestContext context, AcmeAccount account, boolean staging, String[] contactUrls) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.updateAccount(account, staging, contactUrls);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> updateAccount(ElytronRequestContext context, AcmeAccount account, boolean staging, boolean termsOfServiceAgreed, String[] contactUrls) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.updateAccount(account, staging, termsOfServiceAgreed, contactUrls);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> changeAccountKey(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.changeAccountKey(account, staging);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> changeAccountKey(ElytronRequestContext context, AcmeAccount account, boolean staging, X509Certificate certificate, PrivateKey privateKey) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.changeAccountKey(account, staging, certificate, privateKey);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> deactivateAccount(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.deactivateAccount(account, staging);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<X509CertificateChainAndSigningKey> obtainCertificateChain(ElytronRequestContext context, AcmeAccount account, boolean staging, String... domainNames) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.obtainCertificateChain(account, staging, domainNames);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<X509CertificateChainAndSigningKey> obtainCertificateChain(ElytronRequestContext context, AcmeAccount account, boolean staging, String keyAlgorithmName, int keySize,
+                                                                         String... domainNames) {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.obtainCertificateChain(account, staging, keyAlgorithmName, keySize, domainNames);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<String> createAuthorization(ElytronRequestContext context, AcmeAccount account, boolean staging, String domainName) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.createAuthorization(account, staging, domainName);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> deactivateAuthorization(ElytronRequestContext context, AcmeAccount account, boolean staging, String authorizationUrl) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.deactivateAuthorization(account, staging, authorizationUrl);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> revokeCertificate(ElytronRequestContext context, AcmeAccount account, boolean staging, X509Certificate certificate) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.revokeCertificate(account, staging, certificate);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<Void> revokeCertificate(ElytronRequestContext context, AcmeAccount account, boolean staging, X509Certificate certificate, CRLReason reason) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                delegate.revokeCertificate(account, staging, certificate, reason);
+                return null;
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    public Uni<byte[]> getNewNonce(ElytronRequestContext context, final AcmeAccount account, final boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.getNewNonce(account, staging);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    Uni<String[]> queryAccountContactUrls(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.queryAccountContactUrls(account, staging);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    Uni<String> queryAccountStatus(ElytronRequestContext context, AcmeAccount account, boolean staging) throws AcmeException {
+        return context.runBlocking(() -> {
+            try {
+                return delegate.queryAccountStatus(account, staging);
+            } catch (AcmeException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/ElytronRequestContext.java
+++ b/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/ElytronRequestContext.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.wildfly.security.certificate.management.x500.cert.acme;
+
+import io.smallrye.mutiny.Uni;
+
+import java.util.function.Supplier;
+
+public interface ElytronRequestContext {
+    <T> Uni<T>  runBlocking(Supplier<T> function);
+}

--- a/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/SimpleDelegatingAcmeClient.java
+++ b/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/SimpleDelegatingAcmeClient.java
@@ -1,0 +1,370 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.certificate.management.x500.cert.acme;
+
+import io.smallrye.mutiny.Uni;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.wildfly.security.certificate.management.x500.cert.X509CertificateChainAndSigningKey;
+
+import java.net.URL;
+import java.security.PrivateKey;
+import java.security.cert.CRLReason;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class SimpleDelegatingAcmeClient {
+    private AsyncAcmeClientSpi asyncClient;
+    private AcmeClientSpi syncClient;
+
+    private final TestBlockingSecurityExecutor blockingExecutor = TestBlockingSecurityExecutor.createTestBlockingExecutor(() -> {
+        return Executors.newFixedThreadPool(5);
+    });
+    private final ElytronRequestContext testContext = new ElytronRequestContext() {
+        @Override
+        public <T> Uni<T> runBlocking(Supplier<T> function) {
+            return blockingExecutor.executeBlocking(function);
+        }
+    };
+
+    public SimpleDelegatingAcmeClient(boolean useAsync) {
+
+        if (useAsync) {
+            this.asyncClient = new AsyncAcmeClientSpi() {
+                protected AcmeChallenge proveIdentifierControl(AcmeAccount account, List<AcmeChallenge> challenges) throws AcmeException {
+                    return proveIdentifierControlHelper(account, challenges);
+                }
+
+                protected void cleanupAfterChallenge(AcmeAccount account, AcmeChallenge challenge) throws AcmeException {
+                    // do nothing
+                }
+            };
+        } else {
+            this.syncClient = new AcmeClientSpi() {
+                public AcmeChallenge proveIdentifierControl(AcmeAccount account, List<AcmeChallenge> challenges) throws AcmeException {
+                    return proveIdentifierControlHelper(account, challenges);
+                }
+
+                public void cleanupAfterChallenge(AcmeAccount account, AcmeChallenge challenge) throws AcmeException {
+                    // do nothing
+                }
+            };
+        }
+    }
+
+    public Map<AcmeResource, URL> getResourceUrls(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.getResourceUrls(account, staging);
+        } else {
+            return this.asyncClient.getResourceUrls(this.testContext, account, staging).await().indefinitely();
+        }
+    }
+
+    public AcmeMetadata getMetadata(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.getMetadata(account, staging);
+        } else {
+            return this.asyncClient.getMetadata(this.testContext, account, staging).await().indefinitely();
+        }
+    }
+
+    public Boolean createAccount(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.createAccount(account, staging);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            Boolean result = this.asyncClient.createAccount(this.testContext, account, staging)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            } else {
+                return result;
+            }
+        }
+    }
+
+    public boolean createAccount(AcmeAccount account, boolean staging, boolean onlyReturnExisting) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.createAccount(account, staging, onlyReturnExisting);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            Boolean result = this.asyncClient.createAccount(this.testContext, account, staging, onlyReturnExisting)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            } else {
+                return result;
+            }
+        }
+    }
+
+    public void updateAccount(AcmeAccount account, boolean staging, boolean termsOfServiceAgreed) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.updateAccount(account, staging, termsOfServiceAgreed);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            this.asyncClient.updateAccount(this.testContext, account, staging, termsOfServiceAgreed)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            }
+        }
+    }
+
+    public void updateAccount(AcmeAccount account, boolean staging, String[] contactUrls) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.updateAccount(account, staging, contactUrls);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            this.asyncClient.updateAccount(this.testContext, account, staging, contactUrls)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            }
+        }
+    }
+
+    public void updateAccount(AcmeAccount account, boolean staging, boolean termsOfServiceAgreed, String[] contactUrls) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.updateAccount(account, staging, termsOfServiceAgreed, contactUrls);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            this.asyncClient.updateAccount(this.testContext, account, staging, termsOfServiceAgreed, contactUrls)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            }
+        }
+    }
+
+    public void changeAccountKey(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.changeAccountKey(account, staging);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            this.asyncClient.changeAccountKey(this.testContext, account, staging)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            }
+        }
+    }
+
+    public void changeAccountKey(AcmeAccount account, boolean staging, X509Certificate certificate, PrivateKey privateKey) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.changeAccountKey(account, staging, certificate, privateKey);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            this.asyncClient.changeAccountKey(this.testContext, account, staging, certificate, privateKey)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            }
+        }
+    }
+
+    public void deactivateAccount(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.deactivateAccount(account, staging);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            this.asyncClient.deactivateAccount(this.testContext, account, staging)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+
+            }
+        }
+    }
+
+    public X509CertificateChainAndSigningKey obtainCertificateChain(AcmeAccount account, boolean staging, String... domainNames) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.obtainCertificateChain(account, staging, domainNames);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            X509CertificateChainAndSigningKey result = this.asyncClient.obtainCertificateChain(this.testContext, account, staging, domainNames)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            } else {
+                return result;
+            }
+        }
+    }
+
+    public X509CertificateChainAndSigningKey obtainCertificateChain(AcmeAccount account, boolean staging, String keyAlgorithmName, int keySize,
+                                                                    String... domainNames) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.obtainCertificateChain(account, staging, keyAlgorithmName, keySize, domainNames);
+        } else {
+            AtomicReference<String> exceptionMessage = new AtomicReference<>();
+            X509CertificateChainAndSigningKey result = this.asyncClient.obtainCertificateChain(this.testContext, account, staging, keyAlgorithmName, keySize, domainNames)
+                    .onFailure().invoke(t -> {
+                                exceptionMessage.set(t.getMessage());
+                            }
+                    )
+                    .onFailure().recoverWithNull()
+                    .await().indefinitely();
+            if (exceptionMessage.get() != null) {
+                throw new AcmeException(exceptionMessage.get());
+            } else {
+                return result;
+            }
+        }
+    }
+
+    public String createAuthorization(AcmeAccount account, boolean staging, String domainName) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.createAuthorization(account, staging, domainName);
+        } else {
+            return this.asyncClient.createAuthorization(this.testContext, account, staging, domainName).await().indefinitely();
+        }
+    }
+
+    public void deactivateAuthorization(AcmeAccount account, boolean staging, String authorizationUrl) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.deactivateAuthorization(account, staging, authorizationUrl);
+        } else {
+            this.asyncClient.deactivateAuthorization(this.testContext, account, staging, authorizationUrl).await().indefinitely();
+        }
+    }
+
+    public void revokeCertificate(AcmeAccount account, boolean staging, X509Certificate certificate) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.revokeCertificate(account, staging, certificate);
+        } else {
+            this.asyncClient.revokeCertificate(this.testContext, account, staging, certificate).await().indefinitely();
+        }
+    }
+
+    public void revokeCertificate(AcmeAccount account, boolean staging, X509Certificate certificate, CRLReason reason) throws AcmeException {
+        if (this.syncClient != null) {
+            this.syncClient.revokeCertificate(account, staging, certificate, reason);
+        } else {
+            this.asyncClient.revokeCertificate(this.testContext, account, staging, certificate, reason).await().indefinitely();
+        }
+    }
+
+    public byte[] getNewNonce(final AcmeAccount account, final boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.getNewNonce(account, staging);
+        } else {
+            return this.asyncClient.getNewNonce(this.testContext, account, staging).await().indefinitely();
+        }
+    }
+
+    String[] queryAccountContactUrls(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.queryAccountContactUrls(account, staging);
+        } else {
+            return this.asyncClient.queryAccountContactUrls(this.testContext, account, staging).await().indefinitely();
+        }
+    }
+
+    String queryAccountStatus(AcmeAccount account, boolean staging) throws AcmeException {
+        if (this.syncClient != null) {
+            return this.syncClient.queryAccountStatus(account, staging);
+        } else {
+            return this.asyncClient.queryAccountStatus(this.testContext, account, staging).await().indefinitely();
+        }
+    }
+
+    private static AcmeChallenge proveIdentifierControlHelper(AcmeAccount account, List<AcmeChallenge> challenges) throws AcmeException {
+        AcmeChallenge selectedChallenge = null;
+        for (AcmeChallenge challenge : challenges) {
+            if (challenge.getType() == AcmeChallenge.Type.HTTP_01) {
+                AcmeClientSpiTest.getMockWebServerClient().setDispatcher(createChallengeResponseHelper(account, challenge));
+                selectedChallenge = challenge;
+                break;
+            }
+        }
+        return selectedChallenge;
+    }
+
+    private static Dispatcher createChallengeResponseHelper(AcmeAccount account, AcmeChallenge challenge) {
+        return new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest recordedRequest) throws InterruptedException {
+                String path = recordedRequest.getPath();
+                if (path.equals("/.well-known/acme-challenge/" + challenge.getToken())) {
+                    try {
+                        return new MockResponse()
+                                .setHeader("Content-Type", "application/octet-stream")
+                                .setBody(challenge.getKeyAuthorization(account));
+                    } catch (AcmeException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return new MockResponse()
+                        .setBody("");
+            }
+        };
+    }
+
+}

--- a/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/TestBlockingSecurityExecutor.java
+++ b/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/TestBlockingSecurityExecutor.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.security.certificate.management.x500.cert.acme;
+
+import io.smallrye.mutiny.Uni;
+import io.smallrye.mutiny.subscription.UniEmitter;
+
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public interface TestBlockingSecurityExecutor {
+    <T> Uni<T> executeBlocking(Supplier<? extends T> supplier);
+
+    static TestBlockingSecurityExecutor createTestBlockingExecutor(Supplier<Executor> executorSupplier) {
+        return new TestBlockingSecurityExecutor() {
+            @Override
+            public <T> Uni<T> executeBlocking(Supplier<? extends T> function) {
+                return Uni.createFrom().deferred(new Supplier<Uni<? extends T>>() {
+                    @Override
+                    public Uni<? extends T> get() {
+                        return Uni.createFrom().emitter(new Consumer<UniEmitter<? super T>>() {
+                            @Override
+                            public void accept(UniEmitter<? super T> uniEmitter) {
+                                executorSupplier.get().execute(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        try {
+                                            uniEmitter.complete(function.get());
+                                        } catch (Throwable t) {
+                                            uniEmitter.fail(t);
+                                        }
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+        };
+    }
+}


### PR DESCRIPTION
The [AcmeClientSpi](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/AcmeClientSpi.java) class can be used to synchronously communicate with the ACME server, a user only has to implement 2 methods: `proveIdentifierControl` and `cleanupAfterChallenge`, since those are dependent on the environment. For more information, you can look at this blog post: https://wildfly-security.github.io/wildfly-elytron/blog/elytron-acme-client-implementation/ .

This PR adds a new Async ACME client SPI which can be used in the same way but uses [Mutiny library](https://smallrye.io/smallrye-mutiny/2.5.1/).

We want to keep the current blocking API ([AcmeClientSpi](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/AcmeClientSpi.java) class) in the repo for backwards compatibility, since third party libraries might be extending this class. So this PR adds a new class [AsyncAcmeClientSpi](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/AsyncAcmeClientSpi.java) that exposes the same methods, which internally delegate to AcmeClientSpi methods, but the return values are wrapped in [Uni](https://javadoc.io/static/io.smallrye.reactive/mutiny/2.5.1/io.smallrye.mutiny/io/smallrye/mutiny/Uni.html) types. The methods also require the new [ElytronRequestContext](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/main/java/org/wildfly/security/certificate/management/x500/cert/acme/ElytronRequestContext.java) interface passed as a parameter.

All of the methods in AsyncAcmeClientSpi return Uni as all of them are communicating over a network so they are blocking.

Testsuite:
Tests for both APIs are located in [AcmeClientSpiTest](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/AcmeClientSpiTest.java) class. The test methods are being run twice, once with AsyncAcmeClientSpi instance and once with AcmeClientSpi instance. These are being passed as junit's [Parameters](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/AcmeClientSpiTest.java#L126) data. [SimpleDelegatingAcmeClient](https://github.com/Skyllarr/certificate-management/blob/async-spi-with-tests/x500/cert/acme/src/test/java/org/wildfly/security/certificate/management/x500/cert/acme/SimpleDelegatingAcmeClient.java) class was added so it can  be used by tests, it contains either the AcmeClientSpi or AsyncAcmeClientSpi instance. It also contains the methods that are used by tests, but either returns the result directly or uses `.await().indefinitely()` in case of the asynchronous API.

You can build and test the project with `mvn clean install`.